### PR TITLE
Changed deployment target to visionOS 2.0

### DIFF
--- a/SimpleSpace.xcodeproj/project.pbxproj
+++ b/SimpleSpace.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Debug;
 		};
@@ -337,6 +338,7 @@
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 2.0;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Changed deployment target to visionOS 2.0 to avoid issues on older version of visionOS (ex. you wont be able to run visionOS on 2.1 if the default target is not set, because it will assume 2.2)